### PR TITLE
Always return the points

### DIFF
--- a/FindingOrientationOfContours.py
+++ b/FindingOrientationOfContours.py
@@ -101,7 +101,7 @@ class FindingOrientationOfContours(object):
             Bottom = SlopePointB
             Top = DistancePoint
 
-            return (Right, Bottom, Top)
+        return (Right, Bottom, Top)
 
     def CalculatePerpendicularDistance(
               self, DistancePoint, SlopePointA, SlopePointB):


### PR DESCRIPTION
Hi! Noticed an easy to fix bug when testing the project, hope you don't
mind me opening a PR for this :slightly_smiling_face:

`findOrientationBetwwenPoints` was only returning the points if the last
if check was true because the return statement was under that if block.
Looks like this was not indended and caused the processing of the sample
image "Input/qr4" to fail.