### PR TITLE
Fix ValueErrors with testing arrays

### DIFF
--- a/AffineTransformation.py
+++ b/AffineTransformation.py
@@ -11,7 +11,7 @@ import numpy as np
 class AffineTransformation(object):
 
     def __init__(self, image):
-        if not image:
+        if image is None:
             print 'Unable to read the Image. Please provide the image file'
         else:
             self.OriginalImage = image

--- a/Imagehandler.py
+++ b/Imagehandler.py
@@ -22,7 +22,7 @@ class Imagehandler(object):
     def __convertImagetoBlackWhite(self):
         self.Image = cv.imread(self.ImagePath, cv.IMREAD_COLOR)
         self.imageOriginal = self.Image
-        if not self.Image:
+        if self.Image is None:
             print 'some problem with the image'
         else:
             print 'Image Loaded'
@@ -40,7 +40,7 @@ class Imagehandler(object):
         return self.Image
 
     def WritingImage(self, image, path, imageName):
-        if not image:
+        if image is None:
             print 'Image is not valid.Please select some other image'
         else:
             image = cv.cvtColor(image, cv.COLOR_BGR2RGB)

--- a/call.py
+++ b/call.py
@@ -27,7 +27,7 @@ def App():
     for i in xrange(len(paths)):
         obj = Imagehandler(paths[i])
         TransformImage = obj.QRCodeInImage()
-        if not TransformImage:
+        if TransformImage is None:
             print 'Image is not generated'
         obj.WritingImage(
             TransformImage, str(output), 'output' + str(i) + '.jpg')


### PR DESCRIPTION
Testing for the truth value of the arrays was producing this error:

> ValueError: The truth value of an array with more than one element is
> ambiguous. Use a.any() or a.all()

Looks like this this error was introduced in recent numpy versions.